### PR TITLE
Enhance VoodooI2CDeviceNub

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -122,58 +122,18 @@ IOReturn VoodooI2CDeviceNub::getDeviceResourcesDSM(UInt32 index, OSObject **resu
     }
 
     UInt8 availableIndex = *(reinterpret_cast<UInt8 const*>(data->getBytesNoCopy()));
-    data->release();
+    OSSafeReleaseNULL(data);
     *result = nullptr;
 
     if (!(availableIndex & (1 << index))) {
-        IOLog("%s::%s TP7G index 0x%x is not supported\n", getName(), acpi_device->getName(), availableIndex);
+        IOLog("%s::%s Returned index 0x%x from _DSM or XDSM method is not supported\n", getName(), acpi_device->getName(), availableIndex);
         return kIOReturnUnsupportedMode;
     }
 
     return evaluateDSM(I2C_DSM_TP7G, index, result);
 }
 
-IOReturn VoodooI2CDeviceNub::getAlternativeInterrupt(VoodooI2CACPICRSParser* crs_parser) {
-    OSObject *result = nullptr;
-    OSData *data = nullptr;
-    if (getDeviceResourcesDSM(TP7G_GPIO_INDEX, &result) != kIOReturnSuccess ||
-        !(data = OSDynamicCast(OSData, result))) {
-        IOLog("%s::%s Could not retrieve interrupts from _DSM or XDSM method\n", getName(), acpi_device->getName());
-        OSSafeReleaseNULL(result);
-        return kIOReturnNotFound;
-    }
-
-    uint8_t const* crs = reinterpret_cast<uint8_t const*>(data->getBytesNoCopy());
-    crs_parser->parseACPICRS(crs, 0, data->getLength());
-
-    data->release();
-
-    if (!crs_parser->found_gpio_interrupts) {
-        IOLog("%s::%s Failed to find valid interrupts from _DSM or XDSM method\n", getName(), acpi_device->getName());
-        return kIOReturnNotFound;
-    }
-
-    IOLog("%s::%s Found valid interrupts from _DSM or XDSM method\n", getName(), acpi_device->getName());
-    return kIOReturnSuccess;
-}
-
-bool VoodooI2CDeviceNub::validateInterrupt() {
-    OSArray* interrupt_array;
-    OSData* interrupt_data;
-    const UInt16* interrupt_pin;
-    if ((interrupt_array = OSDynamicCast(OSArray, acpi_device->getProperty(gIOInterruptSpecifiersKey))) &&
-        (interrupt_data = OSDynamicCast(OSData, interrupt_array->getObject(0))) &&
-        (interrupt_pin = reinterpret_cast<const UInt16*>(interrupt_data->getBytesNoCopy(0, 1)))) {
-        if (*interrupt_pin <= 0x2f) {
-            has_apic_interrupts = true;
-            return true;
-        }
-        IOLog("%s::%s Warning: Incompatible APIC interrupt pin (0x%x > 0x2f)\n", getName(), acpi_device->getName(), *interrupt_pin);
-    }
-    return false;
-}
-
-IOReturn VoodooI2CDeviceNub::getDeviceResources() {
+IOReturn VoodooI2CDeviceNub::parseResourcesCRS(VoodooI2CACPICRSParser& crs_parser) {
     OSObject *result = nullptr;
     OSData *data = nullptr;
     if (acpi_device->evaluateObject("_CRS", &result) != kIOReturnSuccess ||
@@ -184,23 +144,77 @@ IOReturn VoodooI2CDeviceNub::getDeviceResources() {
     }
 
     uint8_t const* crs = reinterpret_cast<uint8_t const*>(data->getBytesNoCopy());
-    VoodooI2CACPICRSParser crs_parser;
     crs_parser.parseACPICRS(crs, 0, data->getLength());
 
-    data->release();
+    OSSafeReleaseNULL(data);
 
-    if (crs_parser.found_i2c) {
-        use_10bit_addressing = crs_parser.i2c_info.address_mode_10Bit;
-        setProperty("addrWidth", use_10bit_addressing ? 10 : 7, 8);
+    IOLog("%s::%s Found valid resources from _CRS method\n", getName(), acpi_device->getName());
 
-        i2c_address = crs_parser.i2c_info.address;
-        setProperty("i2cAddress", i2c_address, 16);
+    return kIOReturnSuccess;
+}
 
-        setProperty("sclHz", crs_parser.i2c_info.bus_speed, 32);
-    } else {
+IOReturn VoodooI2CDeviceNub::parseResourcesDSM(VoodooI2CACPICRSParser& crs_parser) {
+    OSObject *result = nullptr;
+    OSData *data = nullptr;
+    if (getDeviceResourcesDSM(TP7G_FUNC_INDEX, &result) != kIOReturnSuccess ||
+        !(data = OSDynamicCast(OSData, result))) {
+        IOLog("%s::%s Could not retrieve resources from _DSM or XDSM method\n", getName(), acpi_device->getName());
+        OSSafeReleaseNULL(result);
+        return kIOReturnNotFound;
+    }
+
+    uint8_t const* crs = reinterpret_cast<uint8_t const*>(data->getBytesNoCopy());
+    crs_parser.parseACPICRS(crs, 0, data->getLength());
+
+    OSSafeReleaseNULL(data);
+
+    IOLog("%s::%s Found valid resources from _DSM or XDSM method\n", getName(), acpi_device->getName());
+    return kIOReturnSuccess;
+}
+
+IOReturn VoodooI2CDeviceNub::validateAPICInterrupt() {
+    OSArray* interrupt_array;
+    OSData* interrupt_data;
+    const UInt16* interrupt_pin;
+    if ((interrupt_array = OSDynamicCast(OSArray, acpi_device->getProperty(gIOInterruptSpecifiersKey))) &&
+        (interrupt_data = OSDynamicCast(OSData, interrupt_array->getObject(0))) &&
+        (interrupt_pin = reinterpret_cast<const UInt16*>(interrupt_data->getBytesNoCopy(0, 1)))) {
+        if (*interrupt_pin <= 0x2f) {
+            has_apic_interrupts = true;
+            return kIOReturnSuccess;
+        }
+        IOLog("%s::%s Warning: Incompatible APIC interrupt pin (0x%x > 0x2f)\n", getName(), acpi_device->getName(), *interrupt_pin);
+    }
+    return kIOReturnUnsupported;
+}
+
+IOReturn VoodooI2CDeviceNub::getDeviceResources() {
+    VoodooI2CACPICRSParser crs_parser, dsm_parser;
+
+    parseResourcesCRS(crs_parser);
+    parseResourcesDSM(dsm_parser);
+
+    if (!crs_parser.found_i2c && !dsm_parser.found_i2c) {
         IOLog("%s::%s Could not find an I2C Serial Bus declaration\n", getName(), acpi_device->getName());
         return kIOReturnNotFound;
     }
+
+    if (!crs_parser.found_i2c || (dsm_parser.found_i2c && dsm_parser.found_gpio_interrupts)) {
+        IOLog("%s::%s Prefer resources from _DSM or XDSM method\n", getName(), acpi_device->getName());
+        crs_parser = dsm_parser;
+    }
+
+    use_10bit_addressing = crs_parser.i2c_info.address_mode_10Bit;
+    setProperty("addrWidth", use_10bit_addressing ? 10 : 7, 8);
+
+    i2c_address = crs_parser.i2c_info.address;
+    setProperty("i2cAddress", i2c_address, 16);
+
+    setProperty("sclHz", crs_parser.i2c_info.bus_speed, 32);
+
+    // There is actually no way to avoid APIC interrupt if it is valid
+    if (validateAPICInterrupt() == kIOReturnSuccess)
+        return kIOReturnSuccess;
 
     IOPCIDevice *pci_device { nullptr };
 
@@ -209,21 +223,23 @@ IOReturn VoodooI2CDeviceNub::getDeviceResources() {
     bool force_polling = checkKernelArg("-vi2c-force-polling");
     force_polling = force_polling || ((pci_device != nullptr) && (pci_device->getProperty("force-polling") != nullptr));
 
-    if (!force_polling) {
-        if (crs_parser.found_gpio_interrupts ||
-        (!validateInterrupt() && getAlternativeInterrupt(&crs_parser) == kIOReturnSuccess)) {
+    if (force_polling) {
+        IOLog("%s::%s Forced polling mode, skipping GPIO interrupts\n", getName(), acpi_device->getName());
+        return kIOReturnSuccess;
+    }
+
+    if (crs_parser.found_gpio_interrupts) {
+        IOLog("%s::%s Found valid GPIO interrupts\n", getName(), acpi_device->getName());
+
         setProperty("gpioPin", crs_parser.gpio_interrupts.pin_number, 16);
         setProperty("gpioIRQ", crs_parser.gpio_interrupts.irq_type, 16);
 
         has_gpio_interrupts = true;
         gpio_pin = crs_parser.gpio_interrupts.pin_number;
         gpio_irq = crs_parser.gpio_interrupts.irq_type;
-        }
-    } else {
-        IOLog("%s::%s Forced polling mode, skipping APIC/GPIO interrupts\n", getName(), acpi_device->getName());
     }
 
-    if (!has_apic_interrupts && !has_gpio_interrupts && !force_polling)
+    if (!has_apic_interrupts && !has_gpio_interrupts)
         IOLog("%s::%s Warning: Could not find any APIC nor GPIO interrupts. Your chosen satellite will run in polling mode if implemented.\n", getName(), acpi_device->getName());
 
     return kIOReturnSuccess;

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -26,7 +26,7 @@
 #define I2C_DSM_REVISION 1
 #define DSM_SUPPORT_INDEX 0
 #define HIDG_DESC_INDEX 1
-#define TP7G_GPIO_INDEX 1
+#define TP7G_FUNC_INDEX 1
 
 class VoodooI2CControllerDriver;
 
@@ -209,25 +209,33 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
 
     /* Check if a valid interrupt is available less than 0x2f
      *
-     * @return true if the interrupt can be used
+     * @return *kIOReturnSuccess* if the interrupt can be used
      */
 
-    bool validateInterrupt();
+    IOReturn validateAPICInterrupt();
 
     /* Instantiates a <VoodooI2CACPICRSParser> object to grab I2C slave properties as well as potential GPIO interrupt properties.
      *
-     * @return *kIOReturnSuccess* upon a successfull *_CRS* parse, *kIOReturnNotFound* if no I2C slave properties were found.
+     * @return *kIOReturnSuccess* if resources are collected correctly, *kIOReturnNotFound* if no I2C slave properties were found.
      */
 
     IOReturn getDeviceResources();
 
-    /* Instantiates a <VoodooI2CACPICRSParser> object to retrieve interrupts from _DSM.
+    /* Uses a <VoodooI2CACPICRSParser> object to retrieve resources from _CRS.
      * @crs_parser The parser for default _CRS
      *
-     * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) parse, *kIOReturnNotFound* if no interrupts were found.
+     * @return *kIOReturnSuccess* upon a successfull *_CRS* parse, *kIOReturnNotFound* if no I2C Serial Bus declaration was found.
      */
 
-    IOReturn getAlternativeInterrupt(VoodooI2CACPICRSParser* crs_parser);
+    IOReturn parseResourcesCRS(VoodooI2CACPICRSParser& crs_parser);
+
+    /* Uses a <VoodooI2CACPICRSParser> object to retrieve resources from _DSM.
+     * @crs_parser The parser for default _CRS
+     *
+     * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) parse, *kIOReturnNotFound* if no I2C Serial Bus declaration was found.
+     */
+
+    IOReturn parseResourcesDSM(VoodooI2CACPICRSParser& crs_parser);
 
     /* Searches the IOService plane to find a <VoodooGPIO> controller object.
      */


### PR DESCRIPTION
- Support reading I2C Serial Bus declaration from `_DSM`
- Refactor `VoodooI2CDeviceNub::getDeviceResources()`
- Clarify skipping APIC Interrupt mode
- Slightly adjust logs